### PR TITLE
Couple of fixes

### DIFF
--- a/lang/English/modules/news.php
+++ b/lang/English/modules/news.php
@@ -48,7 +48,7 @@ define('modify_images', "Modify the new article images");
 define('upload_more_images', "Upload more images");
 define('latest_news', "Latest News");
 define('search_results', "Search Results");
-define('no_results', "No news were found.");
+define('no_results', "No news was found.");
 define('config_options', "News Options");
 define('date_format', "Date Format");
 define('results_per_page', "News per Page");

--- a/modules/news/admin.php
+++ b/modules/news/admin.php
@@ -3,16 +3,15 @@ function exec_ogp_module() {
 	define("IN_SCRIPT_ADMIN","1");
 	error_reporting(0);
 
-	include("modules/news/include/SiteManager.class.php");
+	require("modules/news/include/SiteManager.class.php");
 	$website = new SiteManager();
 	$website->SetDataFile("modules/news/data/listings.xml");
 	$website->LoadSettings();
 
 	$website->LoadTemplate();
 
-	if(isset($_REQUEST["page"]))
+	if(!empty($_REQUEST["page"]) && preg_match("/^[a-z]+$/", $_REQUEST['page']))
 	{
-		$website->check_word($_REQUEST["page"]);
 		$website->SetPage($_REQUEST["page"]);
 	}
 	else

--- a/modules/news/include/SiteManager.class.php
+++ b/modules/news/include/SiteManager.class.php
@@ -54,8 +54,7 @@ class SiteManager
 	
 	function LoadTemplate()
 	{
-		global $_REQUEST,$DBprefix;
-		
+
 		if(file_exists("modules/news/pages/template.htm"))
 		{
 			$templateArray=array();
@@ -89,24 +88,24 @@ class SiteManager
 	
 	function Render()
 	{
+		$HTML = '';
+		ob_start();
 		
-		if($this->page!="")
-		{
-			$HTML="";
-			ob_start();
+		if(!file_exists("modules/news/pages/".$this->page.".php")) {
 			
-			if(file_exists("modules/news/pages/".$this->page.".php"))
-			{
-				include("modules/news/pages/".$this->page.".php");
-			
-			}
-			$HTML = ob_get_contents();
-			
-			$this->TemplateHTML=str_replace("<site content/>",$HTML,$this->TemplateHTML);
-			
-			ob_end_clean();
+			// If the given &page value doesn't exist, load either home.php or results.php depending on if the user
+			// is browsing the admin area or not - and display the index/default content.
+			$page = ($_REQUEST['p'] == 'admin_news') ? 'home' : 'results';
+			include("modules/news/pages/$page.php");
+		} else {
+
+			include("modules/news/pages/".$this->page.".php");
 		}
-		
+
+		$HTML = ob_get_contents();
+		$this->TemplateHTML=str_replace("<site content/>",$HTML,$this->TemplateHTML);
+
+		ob_end_clean();
 		echo $this->TemplateHTML;
 	}
 	

--- a/modules/news/index.php
+++ b/modules/news/index.php
@@ -10,9 +10,8 @@ function exec_ogp_module() {
 
 	$website->LoadTemplate();
 
-	if(isset($_REQUEST["page"]))
+	if(!empty($_REQUEST["page"]) && preg_match("/^[a-z]+$/", $_REQUEST['page']))
 	{
-		$website->check_word($_REQUEST["page"]);
 		$website->SetPage($_REQUEST["page"]);
 	}
 

--- a/modules/news/pages/add.php
+++ b/modules/news/pages/add.php
@@ -211,7 +211,7 @@ else{
 							<?php echo get_lang('written_by');?>:
 						</div>
 						<div class="col-md-10">
-							<input class="form-control" type="text" name="written_by" required value="<?php echo $_REQUEST["written_by"];?>"/>
+							<input class="form-control" type="text" name="written_by" required value="<?php echo isset($_REQUEST["written_by"]) ? $_REQUEST["written_by"] : $_SESSION['users_login']; ?>"/>
 						</div>
 					</div>				
 									


### PR DESCRIPTION
If &page is empty or has a period the script halts execution, and if a
value was given for a page that didn't exist we'd see no content.

In the circumstances above, it'll load the default index page now.
Additionally, the written by: section on add.php was changed so it'll
autofill the user's login name.